### PR TITLE
Fixed mumo image name

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - TZ=UTC
 
   mumo:
-    image: goofball/mumo
+    image: goofball222/mumo
     container_name: mumo
     network_mode: service:murmur
     depends_on:


### PR DESCRIPTION
mumo image in the example docker-compose.yml (`goofball/mumo`) doesn't exist. The correct image name is `goofball222/mumo`

@goofball222
